### PR TITLE
 Load planets once on planets screen

### DIFF
--- a/app/src/main/java/com/aidanlaing/exoplanets/screens/planets/PlanetsViewModel.kt
+++ b/app/src/main/java/com/aidanlaing/exoplanets/screens/planets/PlanetsViewModel.kt
@@ -30,11 +30,11 @@ class PlanetsViewModel(
     private val goToSearchEvent = MutableLiveData<SingleEvent>()
     private val showActions = MutableLiveData<Boolean>()
 
-    fun getPlanets(): LiveData<ArrayList<Planet>> {
-        if (planets.value == null) loadPlanets()
-        return planets
+    init {
+        loadPlanets()
     }
 
+    fun getPlanets(): LiveData<ArrayList<Planet>> = planets
     fun goToDetailEvent(): LiveData<SingleDataEvent<PlanetClick>> = goToDetailEvent
     fun planetClicked(planetClick: PlanetClick) {
         goToDetailEvent.value = SingleDataEvent(planetClick)


### PR DESCRIPTION
If you were quick enough to rotate your phone before the first network
call came back, you could trigger multiple calls to the network before
the planets value had been set. This is fixed by adding the initial
loading into the constructor.